### PR TITLE
build(nix): add a nix-based build-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ cd LplKernel
 ./qemu.sh 4 # 4 cores to build
 ```
 
+### Running using nix
+
+```sh
+nix run github:MasterLaplace/LplKernel
+```
+
 ## References
 
 - [OSDev Wiki](https://wiki.osdev.org/Main_Page)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747312588,
+        "narHash": "sha256-MmJvj6mlWzeRwKGLcwmZpKaOPZ5nJb/6al5CXqJsgjo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b1bebd0fe266bbd1820019612ead889e96a8fa2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+      ] (system: function nixpkgs.legacyPackages.${system});
+  in {
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        hardeningDisable = ["fortify"];
+        packages =
+          (builtins.attrValues self.packages.${pkgs.system})
+          ++ (with pkgs; [
+            grub2
+            libisoburn
+            qemu
+        ]);
+      };
+    });
+
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: let
+      pkgs' = self.packages.${pkgs.system};
+      inherit (pkgs) lib callPackage writeShellScriptBin;
+    in {
+      binutils = callPackage ./nix/binutils-2-36.nix {};
+
+      # gcc invoke ar through the environment (AR), but has as hardcorded
+      as = callPackage ./nix/as.nix pkgs';
+
+      gcc = callPackage ./nix/gcc-10-2-0.nix pkgs';
+
+      libc = callPackage ./nix/libc.nix pkgs';
+
+      lpl-kernel = callPackage ./nix/lpl-kernel.nix pkgs';
+
+      iso = callPackage ./nix/iso.nix pkgs';
+
+      default = pkgs'.run-vm;
+
+      run-vm = writeShellScriptBin "run-vm" ''
+        ${lib.getExe pkgs.qemu} -cdrom ${pkgs'.iso}/lpl.iso
+      '';
+    });
+  };
+}

--- a/nix/as.nix
+++ b/nix/as.nix
@@ -1,0 +1,23 @@
+{
+  stdenvNoCC,
+  binutils,
+  lib,
+  ...
+}:
+stdenvNoCC.mkDerivation {
+  pname = "as";
+  inherit (binutils) version;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cp ${lib.getExe' binutils "i686-elf-as"} $out/bin/as
+  '';
+
+  meta = {
+    description = "GNU assembler";
+    license = lib.licenses.gpl3Plus;
+  };
+}

--- a/nix/binutils-2-36.nix
+++ b/nix/binutils-2-36.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "binutils";
+  version = "2.36";
+
+  src = fetchzip {
+    url = "http://ftp.gnu.org/gnu/binutils/binutils-${finalAttrs.version}.tar.gz";
+    hash = "sha256-tSUy7k9CvsMdfzkKXvJYM2OxpipFK0RdUmrIevjsIRI=";
+  };
+
+  configureFlags = [
+    "--target=i686-elf"
+    "--prefix=${placeholder "out"}"
+    "--disable-nls"
+    "--disable-werror"
+  ];
+
+  enableParallelBuilding = true;
+  hardeningDisable = ["all"];
+
+  checkPhase = ''
+    make test
+  '';
+
+  meta = {
+    description = "System binary utilities";
+    license = lib.licenses.gpl3Plus;
+  };
+})

--- a/nix/gcc-10-2-0.nix
+++ b/nix/gcc-10-2-0.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  gmp,
+  mpfr,
+  libmpc,
+  fetchzip,
+  lib,
+  binutils,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gcc";
+  version = "10.2.0";
+
+  src = fetchzip {
+    url = "http://ftp.gnu.org/gnu/gcc/gcc-${finalAttrs.version}/gcc-${finalAttrs.version}.tar.gz";
+    hash = "sha256-xMTbZEEyj0eS3Dkdi6izA88igcSm5arkuM+Xr0xINlA=";
+  };
+
+  preConfigure = ''
+    mkdir build
+    cd build
+  '';
+
+  configureScript = "../configure";
+
+  configureFlags = [
+    "--target=i686-elf"
+    "--prefix=${placeholder "out"}"
+    "--disable-nls"
+    "--enable-languages=c"
+    "--without-headers"
+    "--disable-libssp"
+    "--disable-libquadmath"
+    "--disable-libcc1"
+  ];
+
+  enableParallelBuilding = true;
+  hardeningDisable = ["all"];
+
+  nativeBuildInputs = [
+    gmp
+    mpfr
+    libmpc
+    binutils
+  ];
+
+  makeFlags = [
+    "all-gcc"
+    "all-target-libgcc"
+  ];
+
+  installFlags = [
+    "install-gcc"
+    "install-target-libgcc"
+  ];
+
+  meta = {
+    description = "GNU Compiler Collection";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "i686-elf-gcc";
+  };
+})

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lpl-kernel,
+  grub2,
+  libisoburn,
+  ...
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "libc";
+  inherit (lpl-kernel) version;
+  src = ./..;
+
+  nativeBuildInputs = [
+    lpl-kernel
+    grub2
+    libisoburn
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+
+    cp ${lpl-kernel}/boot/lpl.kernel iso/boot/lpl.kernel
+    grub-mkrescue -o $out/lpl.iso iso
+  '';
+
+  inherit (lpl-kernel) meta;
+})

--- a/nix/libc.nix
+++ b/nix/libc.nix
@@ -1,0 +1,39 @@
+{
+  stdenvNoCC,
+  as,
+  binutils,
+  gcc,
+  lib,
+  lpl-kernel,
+  ...
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "libc";
+  inherit (lpl-kernel) version;
+  src = ../libc;
+
+  env = {
+    HOST = "i686-elf";
+    PREFIX = "${placeholder "out"}";
+    CC = "${lib.getExe gcc}";
+    AR = "${lib.getExe' binutils "i686-elf-ar"}";
+    CFLAGS = "-isystem ${lpl-kernel.src}/include";
+  };
+
+  nativeBuildInputs = [
+    as
+    gcc
+    binutils
+  ];
+
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace-fail 'DEFAULT_HOST!=../default-host.sh' "DEFAULT_HOST:=i686-elf" \
+      --replace-fail 'HOSTARCH!=../target-triplet-to-arch.sh $(HOST)' "HOSTARCH:=i386"
+  '';
+
+  meta = {
+    description = "C libary for the lpl kernel";
+    inherit (lpl-kernel.meta) license;
+  };
+})

--- a/nix/lpl-kernel.nix
+++ b/nix/lpl-kernel.nix
@@ -1,0 +1,42 @@
+{
+  stdenvNoCC,
+  as,
+  binutils,
+  gcc,
+  libc,
+  grub2,
+  lib,
+  ...
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lpl-kernel";
+  version = "dev";
+  src = ../kernel;
+
+  env = {
+    HOST = "i686-elf";
+    PREFIX = "${placeholder "out"}";
+    CC = "${lib.getExe gcc}";
+    AR = "${lib.getExe' binutils "i686-elf-ar"}";
+    CFLAGS = "-isystem ${libc.src}/include";
+    LDFLAGS = "-L ${libc}/lib";
+  };
+
+  nativeBuildInputs = [
+    as
+    gcc
+    binutils
+    grub2
+  ];
+
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace-fail 'DEFAULT_HOST!=../default-host.sh' "DEFAULT_HOST:=i686-elf" \
+      --replace-fail 'HOSTARCH!=../target-triplet-to-arch.sh $(HOST)' "HOSTARCH:=i386"
+  '';
+
+  meta = {
+    description = "Kernel of the Laplace project";
+    license = lib.licenses.gpl3Plus;
+  };
+})


### PR DESCRIPTION
## Changes

**This pull request makes the following changes:**

> added a nix based build-system

This also allows running the kernel via the `run-vm` script remotely, using:
```
nix run github:MasterLaplace/LplKernel
```

## Why

This allow to build and run the kernel all through `nix`, with a single command:

![image](https://github.com/user-attachments/assets/c910320c-280d-4f17-8820-2b5e46a369a5)

The flake expose multiple outputs:
- derivations related to the project
- and a developer shell with all required dependencies to build the project

```
├───devShells
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   └───x86_64-linux: package 'alejandra-4.0.0'
└───packages
    └───x86_64-linux
        ├───as: package 'as-2.36'
        ├───binutils: package 'binutils-2.36'
        ├───default: package 'libc-dev'
        ├───gcc: package 'gcc-10.2.0'
        ├───iso: package 'libc-dev'
        ├───libc: package 'libc-dev'
        ├───lpl-kernel: package 'lpl-kernel-dev'
        └───run-vm: package 'run-vm'
```
